### PR TITLE
config-tool: adding validation in config tool for default autoprune policy

### DIFF
--- a/config-tool/pkg/lib/config/config.go
+++ b/config-tool/pkg/lib/config/config.go
@@ -4,6 +4,7 @@ import (
 	"github.com/quay/quay/config-tool/pkg/lib/fieldgroups/accesssettings"
 	"github.com/quay/quay/config-tool/pkg/lib/fieldgroups/actionlogarchiving"
 	"github.com/quay/quay/config-tool/pkg/lib/fieldgroups/apptokenauthentication"
+	"github.com/quay/quay/config-tool/pkg/lib/fieldgroups/autoprune"
 	"github.com/quay/quay/config-tool/pkg/lib/fieldgroups/bitbucketbuildtrigger"
 	"github.com/quay/quay/config-tool/pkg/lib/fieldgroups/buildmanager"
 	"github.com/quay/quay/config-tool/pkg/lib/fieldgroups/database"
@@ -158,5 +159,10 @@ func NewConfig(fullConfig map[string]interface{}) (Config, error) {
 	}
 	newConfig["BuildManager"] = newBuildManagerFieldGroup
 
+	newAutoPruneFieldGroup, err := autoprune.NewAutoPruneFieldGroup(fullConfig)
+	if err != nil {
+		return newConfig, err
+	}
+	newConfig["AutoPrune"] = newAutoPruneFieldGroup
 	return newConfig, nil
 }

--- a/config-tool/pkg/lib/fieldgroups/autoprune/autoprune.go
+++ b/config-tool/pkg/lib/fieldgroups/autoprune/autoprune.go
@@ -6,12 +6,15 @@ import (
 )
 
 type AutoPruneFieldGroup struct {
-	FEATURE_AUTO_PRUNE           bool                   `default:"false" validate:"" json:"FEATURE_AUTO_PRUNE,omitempty" yaml:"FEATURE_AUTO_PRUNE,omitempty"`
-	DEFAULT_ORG_AUTOPRUNE_POLICY map[string]interface{} `default:"" validate:"" json:"DEFAULT_ORG_AUTOPRUNE_POLICY,omitempty" yaml:"DEFAULT_ORG_AUTOPRUNE_POLICY,omitempty"`
+	FEATURE_AUTO_PRUNE           bool                          `default:"false" validate:"" json:"FEATURE_AUTO_PRUNE,omitempty" yaml:"FEATURE_AUTO_PRUNE,omitempty"`
+	DEFAULT_ORG_AUTOPRUNE_POLICY *DefaultAutoPrunePolicyStruct `default:"" validate:"" json:"DEFAULT_ORG_AUTOPRUNE_POLICY,omitempty" yaml:"DEFAULT_ORG_AUTOPRUNE_POLICY,omitempty"`
 }
 
-// DefaultAutoPrunePolicyStruct represents the DefaultAutoPrunePolicy struct
-type DefaultAutoPrunePolicyStruct map[string]interface{}
+type DefaultAutoPrunePolicyStruct struct {
+	Method string `default:"" validate:"" json:"method,omitempty" yaml:"method,omitempty"`
+	// value can be string or int
+	Value interface{} `default:"" validate:"" json:"value,omitempty" yaml:"value,omitempty"`
+}
 
 // NewAutoPruneFieldGroup creates a new AutoPruneFieldGroup
 func NewAutoPruneFieldGroup(fullConfig map[string]interface{}) (*AutoPruneFieldGroup, error) {
@@ -26,7 +29,6 @@ func NewAutoPruneFieldGroup(fullConfig map[string]interface{}) (*AutoPruneFieldG
 	}
 
 	if value, ok := fullConfig["DEFAULT_ORG_AUTOPRUNE_POLICY"]; ok {
-
 		var err error
 		value := value.(map[string]interface{})
 		newAutoPruneFieldGroup.DEFAULT_ORG_AUTOPRUNE_POLICY, err = NewDefaultOrgAutoPrunePolicyStruct(value)
@@ -38,10 +40,30 @@ func NewAutoPruneFieldGroup(fullConfig map[string]interface{}) (*AutoPruneFieldG
 	return newAutoPruneFieldGroup, nil
 }
 
-func NewDefaultOrgAutoPrunePolicyStruct(defaultConfig map[string]interface{}) (map[string]interface{}, error) {
-	newDefaultOrgAutoPrunePolicyStruct := DefaultAutoPrunePolicyStruct{}
-	for key, value := range defaultConfig {
-		newDefaultOrgAutoPrunePolicyStruct[key] = value
+func NewDefaultOrgAutoPrunePolicyStruct(defaultConfig map[string]interface{}) (*DefaultAutoPrunePolicyStruct, error) {
+	newDefaultOrgAutoPrunePolicyStruct := &DefaultAutoPrunePolicyStruct{}
+	defaults.Set(newDefaultOrgAutoPrunePolicyStruct)
+
+	if value, ok := defaultConfig["method"]; ok {
+		newDefaultOrgAutoPrunePolicyStruct.Method, ok = value.(string)
+		if !ok {
+			return newDefaultOrgAutoPrunePolicyStruct, errors.New("DEFAULT_ORG_AUTOPRUNE_POLICY `method` must be of type string")
+		}
 	}
+
+	if value, ok := defaultConfig["value"]; ok {
+		newDefaultOrgAutoPrunePolicyStruct.Value, ok = value.(int)
+		if ok {
+			return newDefaultOrgAutoPrunePolicyStruct, nil
+		}
+	}
+
+	if value, ok := defaultConfig["value"]; ok {
+		newDefaultOrgAutoPrunePolicyStruct.Value, ok = value.(string)
+		if !ok {
+			return newDefaultOrgAutoPrunePolicyStruct, errors.New("DEFAULT_ORG_AUTOPRUNE_POLICY `value` must be of type string or int")
+		}
+	}
+
 	return newDefaultOrgAutoPrunePolicyStruct, nil
 }

--- a/config-tool/pkg/lib/fieldgroups/autoprune/autoprune.go
+++ b/config-tool/pkg/lib/fieldgroups/autoprune/autoprune.go
@@ -1,0 +1,47 @@
+package autoprune
+
+import (
+	"errors"
+	"github.com/creasty/defaults"
+)
+
+type AutoPruneFieldGroup struct {
+	FEATURE_AUTO_PRUNE           bool                   `default:"false" validate:"" json:"FEATURE_AUTO_PRUNE,omitempty" yaml:"FEATURE_AUTO_PRUNE,omitempty"`
+	DEFAULT_ORG_AUTOPRUNE_POLICY map[string]interface{} `default:"" validate:"" json:"DEFAULT_ORG_AUTOPRUNE_POLICY,omitempty" yaml:"DEFAULT_ORG_AUTOPRUNE_POLICY,omitempty"`
+}
+
+// DefaultAutoPrunePolicyStruct represents the DefaultAutoPrunePolicy struct
+type DefaultAutoPrunePolicyStruct map[string]interface{}
+
+// NewAutoPruneFieldGroup creates a new AutoPruneFieldGroup
+func NewAutoPruneFieldGroup(fullConfig map[string]interface{}) (*AutoPruneFieldGroup, error) {
+	newAutoPruneFieldGroup := &AutoPruneFieldGroup{}
+	defaults.Set(newAutoPruneFieldGroup)
+
+	if value, ok := fullConfig["FEATURE_AUTO_PRUNE"]; ok {
+		newAutoPruneFieldGroup.FEATURE_AUTO_PRUNE, ok = value.(bool)
+		if !ok {
+			return newAutoPruneFieldGroup, errors.New("FEATURE_AUTO_PRUNE must be of type bool")
+		}
+	}
+
+	if value, ok := fullConfig["DEFAULT_ORG_AUTOPRUNE_POLICY"]; ok {
+
+		var err error
+		value := value.(map[string]interface{})
+		newAutoPruneFieldGroup.DEFAULT_ORG_AUTOPRUNE_POLICY, err = NewDefaultOrgAutoPrunePolicyStruct(value)
+		if err != nil {
+			return newAutoPruneFieldGroup, err
+		}
+	}
+
+	return newAutoPruneFieldGroup, nil
+}
+
+func NewDefaultOrgAutoPrunePolicyStruct(defaultConfig map[string]interface{}) (map[string]interface{}, error) {
+	newDefaultOrgAutoPrunePolicyStruct := DefaultAutoPrunePolicyStruct{}
+	for key, value := range defaultConfig {
+		newDefaultOrgAutoPrunePolicyStruct[key] = value
+	}
+	return newDefaultOrgAutoPrunePolicyStruct, nil
+}

--- a/config-tool/pkg/lib/fieldgroups/autoprune/autoprune_fields.go
+++ b/config-tool/pkg/lib/fieldgroups/autoprune/autoprune_fields.go
@@ -1,0 +1,6 @@
+package autoprune
+
+// Fields returns a list of strings representing the fields in this field group
+func (fg *AutoPruneFieldGroup) Fields() []string {
+	return []string{"FEATURE_AUTO_PRUNE", "DEFAULT_ORG_AUTOPRUNE_POLICY"}
+}

--- a/config-tool/pkg/lib/fieldgroups/autoprune/autoprune_test.go
+++ b/config-tool/pkg/lib/fieldgroups/autoprune/autoprune_test.go
@@ -1,0 +1,1 @@
+package autoprune

--- a/config-tool/pkg/lib/fieldgroups/autoprune/autoprune_validator.go
+++ b/config-tool/pkg/lib/fieldgroups/autoprune/autoprune_validator.go
@@ -1,0 +1,30 @@
+package autoprune
+
+import (
+	"github.com/quay/quay/config-tool/pkg/lib/shared"
+)
+
+// Validate checks the configuration settings for this field group
+func (fg *AutoPruneFieldGroup) Validate(opts shared.Options) []shared.ValidationError {
+
+	fgName := "AutoPrune"
+
+	// Make empty errors
+	errors := []shared.ValidationError{}
+
+	// If false, skip validation
+	if fg.FEATURE_AUTO_PRUNE == false {
+		return errors
+	}
+
+	// If npt present, skip validation
+	if fg.DEFAULT_ORG_AUTOPRUNE_POLICY == nil {
+		return errors
+	}
+
+	if ok, err := shared.ValidateDefaultAutoPruneKey(fg.DEFAULT_ORG_AUTOPRUNE_POLICY, "DEFAULT_ORG_AUTOPRUNE_POLICY", fgName); !ok {
+		errors = append(errors, err)
+	}
+
+	return errors
+}

--- a/config-tool/pkg/lib/fieldgroups/autoprune/autoprune_validator.go
+++ b/config-tool/pkg/lib/fieldgroups/autoprune/autoprune_validator.go
@@ -2,6 +2,7 @@ package autoprune
 
 import (
 	"github.com/quay/quay/config-tool/pkg/lib/shared"
+	"regexp"
 )
 
 // Validate checks the configuration settings for this field group
@@ -12,18 +13,70 @@ func (fg *AutoPruneFieldGroup) Validate(opts shared.Options) []shared.Validation
 	// Make empty errors
 	errors := []shared.ValidationError{}
 
-	// If false, skip validation
+	// If FEATURE_AUTO_PRUNE is false, skip validation
 	if fg.FEATURE_AUTO_PRUNE == false {
 		return errors
 	}
 
-	// If npt present, skip validation
+	// If DEFAULT_ORG_AUTOPRUNE_POLICY is not present, skip validation
 	if fg.DEFAULT_ORG_AUTOPRUNE_POLICY == nil {
 		return errors
 	}
 
-	if ok, err := shared.ValidateDefaultAutoPruneKey(fg.DEFAULT_ORG_AUTOPRUNE_POLICY, "DEFAULT_ORG_AUTOPRUNE_POLICY", fgName); !ok {
+	// Check for method key
+	if ok, err := shared.ValidateDefaultAutoPruneKey(fg.DEFAULT_ORG_AUTOPRUNE_POLICY.Method, "DEFAULT_ORG_AUTOPRUNE_POLICY", fgName); !ok {
 		errors = append(errors, err)
+	}
+
+	// Make sure the key `value` exists
+	if fg.DEFAULT_ORG_AUTOPRUNE_POLICY.Value == nil {
+		newError := shared.ValidationError{
+			Tags:       []string{"DEFAULT_ORG_AUTOPRUNE_POLICY"},
+			FieldGroup: fgName,
+			Message:    "DEFAULT_ORG_AUTOPRUNE_POLICY must have the key `value`",
+		}
+		errors = append(errors, newError)
+		return errors
+	}
+
+	// number_of_tags method requires value to be `int`
+	if fg.DEFAULT_ORG_AUTOPRUNE_POLICY.Method == "number_of_tags" {
+		_, ok := fg.DEFAULT_ORG_AUTOPRUNE_POLICY.Value.(int)
+		if !ok {
+			newError := shared.ValidationError{
+				Tags:       []string{"DEFAULT_ORG_AUTOPRUNE_POLICY"},
+				FieldGroup: fgName,
+				Message:    "DEFAULT_ORG_AUTOPRUNE_POLICY method `number_of_tags` must have an integer value",
+			}
+			errors = append(errors, newError)
+			return errors
+		}
+	}
+
+	// creation_date method requires value to be `string`
+	if fg.DEFAULT_ORG_AUTOPRUNE_POLICY.Method == "creation_date" {
+		value, ok := fg.DEFAULT_ORG_AUTOPRUNE_POLICY.Value.(string)
+		if !ok {
+			newError := shared.ValidationError{
+				Tags:       []string{"DEFAULT_ORG_AUTOPRUNE_POLICY"},
+				FieldGroup: fgName,
+				Message:    "DEFAULT_ORG_AUTOPRUNE_POLICY method `creation_date` must have a string type as value",
+			}
+			errors = append(errors, newError)
+			return errors
+		} else {
+			// creation_date value be int followed by one of s,m,d,w,y
+			re, _ := regexp.Compile(`^([0-9]+[smdwy])$`)
+			if !re.MatchString(value) {
+				newError := shared.ValidationError{
+					Tags:       []string{"DEFAULT_ORG_AUTOPRUNE_POLICY"},
+					FieldGroup: fgName,
+					Message:    "DEFAULT_ORG_AUTOPRUNE_POLICY creation_date value must follow: `^([0-9]+[smdwy])$`",
+				}
+				errors = append(errors, newError)
+				return errors
+			}
+		}
 	}
 
 	return errors

--- a/config-tool/pkg/lib/shared/validators.go
+++ b/config-tool/pkg/lib/shared/validators.go
@@ -968,3 +968,25 @@ func ValidateOIDCServer(opts Options, oidcServer, clientID, clientSecret, servic
 	return true, ValidationError{}
 
 }
+
+// ValidateDefaultAutoPruneKey validates that DEFAULT_ORG_AUTORPRUNE_POLICY has key of `number_of_tags` or `creation_date`
+func ValidateDefaultAutoPruneKey(input map[string]interface{}, field string, fgName string) (bool, ValidationError) {
+
+	keys := make([]string, len(input))
+	key := keys[0]
+
+	re := regexp.MustCompile(`^number_of_tags|creation_date$`)
+	matches := re.FindAllString(key, -1)
+
+	// If the pattern is not matched
+	if len(matches) != 1 {
+		newError := ValidationError{
+			Tags:       []string{field},
+			FieldGroup: fgName,
+			Message:    field + "must have `number_of_tags` or `creation_date` as key",
+		}
+		return false, newError
+	}
+
+	return true, ValidationError{}
+}

--- a/config-tool/pkg/lib/shared/validators.go
+++ b/config-tool/pkg/lib/shared/validators.go
@@ -969,21 +969,18 @@ func ValidateOIDCServer(opts Options, oidcServer, clientID, clientSecret, servic
 
 }
 
-// ValidateDefaultAutoPruneKey validates that DEFAULT_ORG_AUTORPRUNE_POLICY has key of `number_of_tags` or `creation_date`
-func ValidateDefaultAutoPruneKey(input map[string]interface{}, field string, fgName string) (bool, ValidationError) {
-
-	keys := make([]string, len(input))
-	key := keys[0]
+// ValidateDefaultAutoPruneKey validates that DEFAULT_ORG_AUTOPRUNE_POLICY has key of `number_of_tags` or `creation_date`
+func ValidateDefaultAutoPruneKey(input string, field string, fgName string) (bool, ValidationError) {
 
 	re := regexp.MustCompile(`^number_of_tags|creation_date$`)
-	matches := re.FindAllString(key, -1)
+	matches := re.FindAllString(input, -1)
 
 	// If the pattern is not matched
 	if len(matches) != 1 {
 		newError := ValidationError{
 			Tags:       []string{field},
 			FieldGroup: fgName,
-			Message:    field + "must have `number_of_tags` or `creation_date` as key",
+			Message:    field + " must have method key with value `number_of_tags` or `creation_date`",
 		}
 		return false, newError
 	}

--- a/config-tool/utils/generate/schema.json
+++ b/config-tool/utils/generate/schema.json
@@ -1146,6 +1146,20 @@
       "ct-default": "",
       "ct-validate": "",
       "ct-fieldgroups": ["LDAP"]
+    },
+    "FEATURE_AUTO_PRUNE": {
+      "x-example": false,
+      "type": "boolean",
+      "description": "If set to true, auto pruning of images is supported. Defaults to False",
+      "ct-default": "false",
+      "ct-validate": ""
+    },
+    "DEFAULT_ORG_AUTOPRUNE_POLICY": {
+      "x-example": {"number_of_tags":  "10"},
+      "type": "object",
+      "description": "Default org wide auto prune policy. Defaults to empty",
+      "ct-default": "",
+      "ct-validate": ""
     }
   }
 }

--- a/config-tool/utils/scripts/dumpschema.py
+++ b/config-tool/utils/scripts/dumpschema.py
@@ -1161,6 +1161,16 @@ CONFIG_SCHEMA = {
             "description": "The set of hostnames to disallow from webhooks when validating, beyond localhost",
             "x-example": ["somexternaldomain.com"],
         },
+        "FEATURE_AUTO_PRUNE": {
+            "type": "boolean",
+            "description": "If set to true, auto pruning of images is supported. Defaults to False",
+            "x-example": False,
+        },
+        "DEFAULT_ORG_AUTOPRUNE_POLICY": {
+            "type": "object",
+            "description": "Default org wide auto prune policy. Defaults to empty",
+            "x-example": {"number_of_tags":  "10"},
+        }
     },
 }
 


### PR DESCRIPTION
Checks the following:
1.  `FEATURE_AUTO_PRUNE` must be of type bool
2. `DEFAULT_ORG_AUTOPRUNE_POLICY` must be of type dictionary
3. `DEFAULT_ORG_AUTOPRUNE_POLICY` supports either `number_of_tags` or `creation_date` as keys
4. Validation on `value` for `number_of_tags` and `creation_date` as keys