### PR TITLE
NO-ISSUE: fix(testing): align cherry-picked e2e tests with redhat-3.17 components

### DIFF
--- a/web/playwright/e2e/api/api-v1-advanced-features.spec.ts
+++ b/web/playwright/e2e/api/api-v1-advanced-features.spec.ts
@@ -541,8 +541,10 @@ test.describe('Registry Status & Size', {tag: ['@api']}, () => {
     const calcResp = await adminClient.post('/api/v1/superuser/registrysize/');
     expect([201, 202]).toContain(calcResp.status());
 
-    // Poll until size is available (replaces cy.wait(180000)).
-    // Return null for not-ready so the assertion cannot pass prematurely.
+    // Poll until the calculation completes and size_bytes is a valid number.
+    // Do NOT require size_bytes > 0: CI only creates repos/orgs via API and
+    // never pushes image blobs, so the registry legitimately has 0 bytes.
+    // Asserting > 0 caused guaranteed 180 s timeouts on every clean CI run.
     await expect
       .poll(
         async () => {
@@ -552,7 +554,9 @@ test.describe('Registry Status & Size', {tag: ['@api']}, () => {
           if (sizeResp.status() !== 200) return null;
           const body = await sizeResp.json();
           const bytes = body.size_bytes;
-          return typeof bytes === 'number' && bytes > 0 ? bytes : null;
+          // Return the value only once the backend has finished calculating
+          // (size_bytes will be null/undefined until the async job completes).
+          return typeof bytes === 'number' ? bytes : null;
         },
         {
           message: 'Waiting for registry size calculation to complete',
@@ -560,7 +564,7 @@ test.describe('Registry Status & Size', {tag: ['@api']}, () => {
           intervals: [5_000, 10_000, 15_000],
         },
       )
-      .toBeGreaterThan(0);
+      .toBeGreaterThanOrEqual(0);
   });
 });
 

--- a/web/playwright/e2e/organization/org-mirroring.spec.ts
+++ b/web/playwright/e2e/organization/org-mirroring.spec.ts
@@ -907,10 +907,10 @@ test.describe(
       // Open cancel modal
       await authenticatedPage.getByTestId('cancel-sync-button').click();
 
-      // Verify updated modal text: future syncs continue
+      // Verify modal text about cancelling syncs
       await expect(
         authenticatedPage.getByText(
-          'Future scheduled syncs will continue as normal.',
+          'in-progress and scheduled syncs will be stopped',
         ),
       ).toBeVisible();
 

--- a/web/playwright/e2e/superuser/repo-tag-actions.spec.ts
+++ b/web/playwright/e2e/superuser/repo-tag-actions.spec.ts
@@ -19,6 +19,9 @@ test.describe(
       // Click create repository
       await superuserPage
         .getByRole('button', {name: 'Create Repository'})
+        .waitFor({state: 'visible', timeout: 30000});
+      await superuserPage
+        .getByRole('button', {name: 'Create Repository'})
         .click();
 
       // Fill in repository name
@@ -29,8 +32,12 @@ test.describe(
       // Select private visibility
       await superuserPage.getByTestId('visibility-private-radio').click();
 
-      // Submit
-      await superuserPage.getByTestId('create-repository-submit-btn').click();
+      // Wait for form to stabilize after radio toggle re-render
+      const submitBtn = superuserPage.getByTestId(
+        'create-repository-submit-btn',
+      );
+      await expect(submitBtn).toBeEnabled();
+      await submitBtn.click();
 
       // Verify success alert appears
       await expect(

--- a/web/playwright/e2e/usage-logs.spec.ts
+++ b/web/playwright/e2e/usage-logs.spec.ts
@@ -457,7 +457,7 @@ test.describe(
       s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
     test(
-      'superuser view shows only repo name in Repository column (not namespace/repo)',
+      'superuser view shows full namespace/repo in Repository column',
       {tag: '@superuser'},
       async ({superuserPage, superuserApi}) => {
         // Creating a repo generates a real create_repo log with {namespace, repo} metadata
@@ -477,17 +477,14 @@ test.describe(
 
         // Scope to td cells with exact text to avoid matching Description column.
         // Escape regex metacharacters in case generated names contain them.
-        const repoNameCell = table
+        const fullNameCell = table
           .locator('td')
-          .filter({hasText: new RegExp(`^${escapeRegex(repoName)}$`)});
-        await expect(repoNameCell.first()).toBeVisible();
-        await expect(
-          table.locator('td').filter({
+          .filter({
             hasText: new RegExp(
               `^${escapeRegex(orgName)}/${escapeRegex(repoName)}$`,
             ),
-          }),
-        ).not.toBeVisible();
+          });
+        await expect(fullNameCell.first()).toBeVisible();
       },
     );
 


### PR DESCRIPTION
## Summary
- Fixes 4 Playwright e2e test failures introduced by the cherry-pick of #6000 into `redhat-3.17`
- The tests were cherry-picked from `master` but depend on component changes not yet backported — this adjusts the tests to match current `redhat-3.17` component behavior

### Fixes
- **org-mirroring.spec.ts**: Updated cancel-sync modal assertion to match current `OrgMirroringStatus.tsx` text
- **usage-logs.spec.ts**: Changed superuser Repository column test to expect `namespace/repo` format (current `UsageLogsTable.tsx` behavior)
- **api-v1-advanced-features.spec.ts**: Relaxed registry size assertion to `toBeGreaterThanOrEqual(0)` since CI never pushes image blobs
- **repo-tag-actions.spec.ts**: Added `waitFor` and `toBeEnabled` guards to prevent race condition timeouts

## Test plan
- [ ] Playwright E2E Tests CI check passes
- [ ] No regressions in other test suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)